### PR TITLE
Add feature flag guard to public api

### DIFF
--- a/projects/ngx-feature-flags/src/public-api.ts
+++ b/projects/ngx-feature-flags/src/public-api.ts
@@ -4,3 +4,4 @@
 
 export * from './lib/ngx-feature-flags.service';
 export * from './lib/ngx-feature-flags.module';
+export * from './lib/feature-flags.guard';


### PR DESCRIPTION
Adding the guard to the public API, so that the guard can be imported and the documentation is correct.